### PR TITLE
Restart webview if process killed.

### DIFF
--- a/Sources/SwiftBlade/SwiftBlade.swift
+++ b/Sources/SwiftBlade/SwiftBlade.swift
@@ -591,6 +591,15 @@ extension SwiftBlade: WKNavigationDelegate {
         // Call initBladeSdkJS and initCompletion after that
         try? self.initBladeSdkJS()
     }
+    
+    public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        // if webview process killed - reload it. Init triggers at WKNavigationDelegate{webView}. Nice 👌
+        webView.reload()
+        /**
+         //to test on simulator run in cli: kill child process of simulator with 'com.apple.WebKit.WebContent' in title
+         `kill $(pgrep -P $(pgrep launchd_sim) 'com.apple.WebKit.WebContent')`
+        */
+    }
 }
 
 // MARK: - JS wrapper response types


### PR DESCRIPTION
In case when app runs in background for a while, or high memory impact of active apps process of webview may be killed. So we need to reload it, and init with data.